### PR TITLE
Fixed filterConstraints.notEquals

### DIFF
--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -1752,7 +1752,15 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         },
 		
         notEquals(value, filter): boolean {
-            return !this.equals(value, filter);
+            if(filter === undefined || filter === null || (typeof filter === 'string' && filter.trim() === '')) {
+                return false;
+            }
+            
+            if(value === undefined || value === null) {
+                return true;
+            }
+            
+            return value.toString().toLowerCase() != filter.toString().toLowerCase();
         },
         
         in(value, filter: any[]): boolean {


### PR DESCRIPTION
Neither a JS litteral nor a variable use this context. This mades notEquals unable to access equals. Simplest way to fix it was rewrite notEquals. Converting the litteral to a true object would also fix the problem but require more redisign.

###Defect Fixes
[https://github.com/primefaces/primeng/issues/3388](url)